### PR TITLE
feat: add `color-scheme` meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 			content="A smart shopping list that learns your purchase habits and makes suggestions, so you don't forget to buy what's important."
 		/>
 		<link rel="icon" type="image/svg+xml" href="/src/favicon.ico" />
-		<meta name="theme-color" content="#000000" />
+		<meta name="color-scheme" content="dark light" />
 		<title>Smart Shopping List</title>
 		<script type="module" src="/src/index.jsx" async></script>
 	</head>


### PR DESCRIPTION
## Description

The `color-scheme` meta tag allows an author to tell the browser which color schemes a webpage supports. Indicating this support has some subtle, positive effects. For one thing: it tells the browser to choose a different default stylesheet in dark mode, which improves the color contrast of buttons, links, and various form controls.

Here's an unstyled button and link _before_ adding the color-scheme meta (in Chromium Edge MacOS)
<img width="106" alt="CleanShot 2023-03-14 at 21 09 44@2x" src="https://user-images.githubusercontent.com/13525251/225205113-2ccfc1a0-11d2-491f-ad1e-34e09efa0eaf.png">

Here's an unstyled button and link _after_ adding the color-scheme meta (in Chromium Edge MacOS)
<img width="106" alt="CleanShot 2023-03-14 at 21 09 27@2x" src="https://user-images.githubusercontent.com/13525251/225205221-23c75ea9-60f7-4293-bcd5-fbbe466acac8.png">

Notice that in the before case, the user agent's link color is hard to read against our dark background, and the button is a jarring white. In the after case, the user agent's default link color is not as bright, and more suited to a dark background; and the button is also dark.

Authors (our collabies) can, of course, choose their own styles later on, but this will give them some more-accessible defaults.

## Further reading
- [`color scheme` meta tag in the HTML spec](https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme)
- [`color-scheme` CSS property at MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) (the syntax for the meta tag and css property match; the meta tag is a faster way to make the browser discover the author's preferences)