### PR TITLE
chore: set package type to "module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "smart-shopping-list-next",
+	"type": "module",
 	"private": false,
 	"engines": {
 		"node": ">=18.12.0",


### PR DESCRIPTION
## Description

As it says on the tin!

1. This unlocks a little bit of automation for future project setup; details to come in Slack 👀
2. We should be using `type: module` anyway, as this is a modern app intended for modern JS runtimes. Luckily, omitting `type: module` up 'til now hasn't caused any problems, as Vite targets modern environments anyway. Still, better to match the expected output in case any strangeness does crop up.