### PR TITLE
chore: add .firebaserc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# firebase config
+.firebaserc


### PR DESCRIPTION
## Description
This way, we don't need to change the gitignore file in every project during the setup stage.