### PR TITLE
feat: overhall layout styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -59,7 +59,7 @@ body {
 	color: var(--color-text);
 	font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui,
 		helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif;
-	font-size: 1.6rem;
+	font-size: 1.8rem;
 	line-height: 1.4;
 	margin: 0;
 

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@
 
 	--color-accent: var(--color-pastel-blue);
 	--color-bg: var(--color-black);
-	--color-bg-well: var(--color-gray-dark);
+	--color-border: hsla(220, 13%, 32%, 1);
 	--color-error: var(--color-red);
 	--color-text: var(--color-white);
 }
@@ -20,7 +20,7 @@
 	:root {
 		--color-accent: var(--color-cobalt-blue);
 		--color-bg: var(--color-white);
-		--color-bg-well: var(--color-gray-light);
+		--color-border: hsla(220, 13%, 78%, 1);
 		--color-text: var(--color-black);
 	}
 }
@@ -28,7 +28,7 @@
 :root.theme-light {
 	--color-accent: var(--color-cobalt-blue);
 	--color-bg: var(--color-white);
-	--color-bg-well: var(--color-gray-light);
+	--color-border: hsla(220, 13%, 78%, 1);
 	--color-text: var(--color-black);
 }
 
@@ -40,16 +40,9 @@
 
 /**
  * Make sure the app fills the height of the screen.
- * The fill-available value allows the browser to account
- * for the address bar and other browser chrome on mobile.
  */
-html,
-body,
-#root,
-#root > * {
-	height: 100vh;
-	height: -webkit-fill-available;
-	height: fill-available;
+body {
+	height: 100dvh;
 }
 
 /**
@@ -96,8 +89,4 @@ code {
 
 :root.theme-light code {
 	--color-bg: var(--color-gray-light);
-}
-
-ul {
-	padding: 0;
 }

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -59,7 +59,7 @@
 	--color-text: var(--color-accent);
 
 	color: var(--color-text);
-	font-size: 1.6em;
+	font-size: 1.4em;
 	flex: 0 1 auto;
 	line-height: 1;
 	padding: 0.8rem;

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -10,47 +10,58 @@
 .Layout {
 	display: flex;
 	flex-direction: column;
-	margin: 0 auto;
-	max-width: 100vw;
-	width: 54rem;
+	height: 100dvh;
+}
+
+.Layout > * {
+	padding-inline: min(5dvw, 3.2rem);
 }
 
 .Layout-header {
 	background-color: var(--color-bg);
+	padding-bottom: 0.5rem;
 	padding-top: max(env(safe-area-inset-top), 1rem);
-	position: sticky;
 	text-align: center;
-	top: 0;
 }
 
 .Layout-header > h1 {
-	margin-top: 0;
+	margin: 0;
 }
 
 .Layout-main {
 	margin: 0 auto;
-	max-width: 95vw;
-	width: 95%;
+	padding-block: 0;
+	padding-block-end: 6.26rem;
+	width: min(72ch, 100%);
 }
 
 .Nav {
-	align-items: stretch;
 	background-color: var(--color-bg);
+	border-top: 1px solid var(--color-border);
 	bottom: 0;
 	display: flex;
 	flex-direction: row;
-	justify-content: space-around;
-	margin-top: auto;
 	padding-bottom: max(env(safe-area-inset-bottom), 1rem);
-	position: sticky;
+	padding-top: 1rem;
+	place-content: center;
+	position: fixed;
+	width: 100%;
+}
+
+.Nav-container {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-evenly;
+	width: min(72ch, 100%);
 }
 
 .Nav-link {
 	--color-text: var(--color-accent);
 
 	color: var(--color-text);
-	font-size: 1.45em;
+	font-size: 1.6em;
 	flex: 0 1 auto;
+	line-height: 1;
 	padding: 0.8rem;
 	text-align: center;
 	text-underline-offset: 0.1em;

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -21,15 +21,17 @@ export function Layout() {
 					<Outlet />
 				</main>
 				<nav className="Nav">
-					<a href="#" className="Nav-link">
-						Home
-					</a>
-					<a href="#" className="Nav-link">
-						List
-					</a>
-					<a href="#" className="Nav-link">
-						Add Item
-					</a>
+					<div className="Nav-container">
+						<a href="#" className="Nav-link">
+							Home
+						</a>
+						<a href="#" className="Nav-link">
+							List
+						</a>
+						<a href="#" className="Nav-link">
+							Add Item
+						</a>
+					</div>
 				</nav>
 			</div>
 		</>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -8,11 +8,8 @@ export function List({ data }) {
 			</p>
 			<ul>
 				{/**
-				{new Array(100).fill(null).map((_, i) => (
 				 * TODO: write some JavaScript that renders the `data` array
-					<li style={{ fontSize: '2em' }}>item {i}</li>
 				 * using the `ListItem` component that's imported at the top
-				))}
 				 * of this file.
 				 */}
 			</ul>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -8,8 +8,11 @@ export function List({ data }) {
 			</p>
 			<ul>
 				{/**
+				{new Array(100).fill(null).map((_, i) => (
 				 * TODO: write some JavaScript that renders the `data` array
+					<li style={{ fontSize: '2em' }}>item {i}</li>
 				 * using the `ListItem` component that's imported at the top
+				))}
 				 * of this file.
 				 */}
 			</ul>


### PR DESCRIPTION
## Summary

This PR adjusts the font sizes and layout of the starting design.

- The body font is now slightly larger at ~18px
- The app width is constrained to 72ch, instead of 54rem, so it is allowed to be a little wider
- The navbar is now full-width and has a top border to separate it from the rest of the content

## Screenshots
Here's how the app looks at 100% zoom in a 1000px-wide viewport (list items to demonstrate how the content flows under the navbar)
![shopping-list-redesign](https://github.com/the-collab-lab/smart-shopping-list/assets/13525251/dfcf0055-2de7-4395-83c8-c6e42028f271)
